### PR TITLE
fix: windows non-default generator broken

### DIFF
--- a/recipe/0.1.0-winfix.patch
+++ b/recipe/0.1.0-winfix.patch
@@ -1,0 +1,25 @@
+From 4671c34a1a2510019030a7fd8c8bd7614b50b0e6 Mon Sep 17 00:00:00 2001
+From: Henry Schreiner <henryschreineriii@gmail.com>
+Date: Thu, 24 Nov 2022 08:10:35 -0500
+Subject: [PATCH] fix: windows non-default generators
+
+Signed-off-by: Henry Schreiner <henryschreineriii@gmail.com>
+---
+ src/scikit_build_core/builder/builder.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/scikit_build_core/builder/builder.py b/src/scikit_build_core/builder/builder.py
+index 87594dd..f3f951e 100644
+--- a/src/scikit_build_core/builder/builder.py
++++ b/src/scikit_build_core/builder/builder.py
+@@ -82,7 +82,9 @@ def configure(
+         if fp_backport and self.config.cmake.version < Version(fp_backport):
+             self.config.module_dirs.append(Path(find_python.__file__).parent.resolve())
+ 
+-        if sys.platform.startswith("win32"):
++        if sys.platform.startswith("win32") and "Visual Studio" in self.config.env.get(
++            "CMAKE_GENERATOR", "Visual Studio"
++        ):
+             # TODO: support cross-compilation
+             is_64bit = sys.maxsize > 2**32
+             if not is_64bit:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,13 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/scikit_build_core-{{ version }}.tar.gz
   sha256: 3b51c88fb99d2cca488cc262fa659ad3d403e2a038f8ad1d87e5f36ff6cc8deb
+  patches:
+    - 0.1.0-winfix.patch
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Currently Windows is broken in the build environment (not the test environment) due to non-default generators being broken. Upstream patch at https://github.com/scikit-build/scikit-build-core/pull/137

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
